### PR TITLE
added ipython notebook for example script

### DIFF
--- a/examples/Data Pipeline.ipynb
+++ b/examples/Data Pipeline.ipynb
@@ -287,6 +287,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# some documents have failed to load because the date format is malformed. "
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {
     "collapsed": true

--- a/greencall/crawlah.py
+++ b/greencall/crawlah.py
@@ -9,7 +9,6 @@ import codecs
 import logging
 from time import gmtime, strftime, sleep, time
 
-import requests
 from twisted.internet import reactor
 from twisted.web.client import getPage
 from twisted.web.error import Error


### PR DESCRIPTION
In response to #3, IPython notebook added as data pipeline example. I've decided to use an IPython notebook as the 'Admin' page for the greenCall package. So this notebook will get updated as the Python package improves
